### PR TITLE
Add pre-1.0 versioning warning in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to SmartScanner Android
 
-Thank you for your interest to contribute to SmartScanner Android! We want to make contributing to this project as easy as possible, whether it's:
+Thank you for your interest to contribute to SmartScanner Android API! We want to make contributing to this project as easy as possible, whether it's:
 
 - Reporting a bug
 - Discussing the current state of the code
@@ -23,7 +23,7 @@ All code changes happen through pull requests. Your pull requests to the codebas
 
 ## Reporting bugs
 
-We use [GitHub issues](https://github.com/idpass/smartscanner-android/issues) to track bugs. Report a bug by [opening a new issue](https://github.com/idpass/smartscanner-android/issues/new).
+We use [GitHub issues](https://github.com/idpass/smartscanner-android-api/issues) to track bugs. Report a bug by [opening a new issue](https://github.com/idpass/smartscanner-android-api/issues/new).
 
 Write bug reports with detail, background, and sample code. An issue template is provided when opening a new issue, make sure to provide all the requested information to make it easier to address the issue.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SmartScanner Android
+# SmartScanner Android API
 
 Convenience API for [SmartScanner Core](https://github.com/idpass/smartscanner-core/) to simplify the Intent call out process.
 
@@ -16,11 +16,11 @@ repositories {
 }
 
 dependencies {
-  implementation "org.idpass:smartscanner-android:0.0.1-SNAPSHOT"
+  implementation "org.idpass:smartscanner-android-api:0.0.1-SNAPSHOT"
 }
 ```
 
-If you want to build this library from source, instructions to do so can be found in the [Building from source](https://github.com/idpass/smartscanner-android/wiki/Building-from-source) wiki page.
+If you want to build this library from source, instructions to do so can be found in the [Building from source](https://github.com/idpass/smartscanner-android-api/wiki/Building-from-source) wiki page.
 
 ## Usage
 
@@ -86,6 +86,12 @@ class MainActivity : AppCompatActivity() {
 #### `ScannerConstants`
 
 Provides [constant variables](app/src/main/java/org/idpass/smartscanner/api/ScannerConstants.kt) that can be used instead of hardcoded strings. We recommend using these constants when working with this library and [smartscanner-core](https://github.com/idpass/smartscanner-core/).
+
+## Related projects
+
+- [smartscanner-core](https://github.com/idpass/smartscanner-core) - Android library for scanning MRZ, Barcode, and ID PASS Lite cards
+- [smartscanner-capacitor](https://github.com/idpass/smartscanner-capacitor) - SmartScanner [Capacitor](https://capacitorjs.com/) plugin
+- [smartscanner-cordova](https://github.com/idpass/smartscanner-cordova) - SmartScanner [Cordova](https://cordova.apache.org/) plugin
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Convenience API for [SmartScanner Core](https://github.com/idpass/smartscanner-c
 
 This library provides methods that can be called to initiate scanning of MRZ, barcode, and [ID PASS Lite](https://github.com/idpass/idpass-lite) cards, instead of manually creating and calling intents.
 
+**Note: The library's API might keep evolving before we reach v1.0, so be careful when upgrading between these pre-v1.0 versions. Starting at v1.0 we will be careful in introducing breaking API changes.**
+
 ## Installation
 
 Declare Maven Central repository in the dependency configuration, then add this library in the dependencies. An example using `build.gradle`:


### PR DESCRIPTION
## Issue

<!-- Provide a reference to the issue that this change is going to address -->
<!-- E.g. #12 Issue title here -->

#4 Documentation

## Changes

<!-- Provide a detailed description of the changes proposed in this PR -->

1. Add warning message in README about pre-v1.0 versions
1. Update links and examples to use `smartscanner-android-api`
